### PR TITLE
DX: marks `docs` folder as non-documentation for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # GitHub syntax highlighting
 pixi.lock linguist-language=YAML
+# Github doesn't recognize the docs folder as a documentation folder
+docs/* linguist-documentation=false


### PR DESCRIPTION
Closes #22 

<!--
For the PR title, follow a conventional commit message style:
https://compwa.github.io/develop#commit-conventions
-->

<!--
Contents of this PR appear in the release notes. Please use screenshots, code snippets
etc. to illustrate proposed changes
-->
