### PR TITLE
DOC: render `ipympl` plots as exported figures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,10 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        exclude: >-
+          (?x)^(
+            .*\.ipynb
+          )$
 
   - repo: https://github.com/redeboer/taplo-pre-commit
     rev: 0.9.1rc1

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,4 @@
+*.png
+*.svg
 .ipynb_checkpoints
 _build

--- a/docs/eta-pi-p/automated.ipynb
+++ b/docs/eta-pi-p/automated.ipynb
@@ -46,7 +46,7 @@
     "import sympy as sp\n",
     "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "from ampform.io import aslatex, improve_latex_rendering\n",
-    "from IPython.display import Math, display\n",
+    "from IPython.display import SVG, Math, display\n",
     "from qrules.particle import Particle, Spin, create_particle, load_pdg\n",
     "from tensorwaves.data import (\n",
     "    SympyDataTransformer,\n",
@@ -55,12 +55,17 @@
     ")\n",
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "\n",
+    "STATIC_PAGE = \"EXECUTE_NB\" in os.environ\n",
+    "\n",
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\"\n",
     "logging.disable(logging.WARNING)\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "improve_latex_rendering()\n",
-    "particle_db = load_pdg()"
+    "particle_db = load_pdg()\n",
+    "\n",
+    "if STATIC_PAGE:\n",
+    "    plt.ioff()"
    ]
   },
   {
@@ -398,6 +403,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-input",
      "full-width",
@@ -470,9 +478,14 @@
     "interactive_plot = w.interactive_output(update_plot, sliders)\n",
     "for ax in axes:\n",
     "    ax.legend(fontsize=\"small\")\n",
-    "\n",
     "fig.tight_layout()\n",
-    "display(UI, interactive_plot)"
+    "\n",
+    "if STATIC_PAGE:\n",
+    "    filename = \"1d-histograms.svg\"\n",
+    "    fig.savefig(filename)\n",
+    "    display(UI, SVG(filename))\n",
+    "else:\n",
+    "    display(UI, interactive_plot)"
    ]
   }
  ],
@@ -492,7 +505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/eta-pi-p/automated.ipynb
+++ b/docs/eta-pi-p/automated.ipynb
@@ -62,10 +62,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "improve_latex_rendering()\n",
-    "particle_db = load_pdg()\n",
-    "\n",
-    "if STATIC_PAGE:\n",
-    "    plt.ioff()"
+    "particle_db = load_pdg()"
    ]
   },
   {

--- a/docs/eta-pi-p/automated.ipynb
+++ b/docs/eta-pi-p/automated.ipynb
@@ -483,6 +483,7 @@
     "if STATIC_PAGE:\n",
     "    filename = \"1d-histograms.svg\"\n",
     "    fig.savefig(filename)\n",
+    "    plt.close(fig)\n",
     "    display(UI, SVG(filename))\n",
     "else:\n",
     "    display(UI, interactive_plot)"

--- a/docs/lambda-k-pi/automated.ipynb
+++ b/docs/lambda-k-pi/automated.ipynb
@@ -67,10 +67,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "improve_latex_rendering()\n",
-    "particle_db = load_pdg()\n",
-    "\n",
-    "if STATIC_PAGE:\n",
-    "    plt.ioff()"
+    "particle_db = load_pdg()"
    ]
   },
   {

--- a/docs/lambda-k-pi/automated.ipynb
+++ b/docs/lambda-k-pi/automated.ipynb
@@ -51,7 +51,7 @@
     "import sympy as sp\n",
     "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "from ampform.io import aslatex, improve_latex_rendering\n",
-    "from IPython.display import Markdown, Math, display\n",
+    "from IPython.display import SVG, Image, Markdown, Math, display\n",
     "from qrules.particle import Particle, Spin, create_particle, load_pdg\n",
     "from tensorwaves.data import (\n",
     "    SympyDataTransformer,\n",
@@ -60,12 +60,17 @@
     ")\n",
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "\n",
+    "STATIC_PAGE = \"EXECUTE_NB\" in os.environ\n",
+    "\n",
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\"\n",
     "logging.disable(logging.WARNING)\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "improve_latex_rendering()\n",
-    "particle_db = load_pdg()"
+    "particle_db = load_pdg()\n",
+    "\n",
+    "if STATIC_PAGE:\n",
+    "    plt.ioff()"
    ]
   },
   {
@@ -610,8 +615,7 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input",
-     "full-width"
+     "hide-input"
     ]
    },
    "outputs": [],
@@ -650,7 +654,13 @@
     "interactive_plot = w.interactive_output(update_histogram, sliders)\n",
     "fig_2d.tight_layout()\n",
     "fig_2d.colorbar(mesh, ax=ax_2d)\n",
-    "display(UI, interactive_plot)"
+    "\n",
+    "if STATIC_PAGE:\n",
+    "    filename = \"dalitz-plot.png\"\n",
+    "    fig_2d.savefig(filename)\n",
+    "    display(UI, Image(filename))\n",
+    "else:\n",
+    "    display(UI, interactive_plot)"
    ]
   },
   {
@@ -729,9 +739,14 @@
     "interactive_plot = w.interactive_output(update_plot, sliders)\n",
     "for ax in axes:\n",
     "    ax.legend(fontsize=\"small\")\n",
-    "\n",
     "fig.tight_layout()\n",
-    "display(UI, interactive_plot)"
+    "\n",
+    "if STATIC_PAGE:\n",
+    "    filename = \"histogram.svg\"\n",
+    "    fig.savefig(filename)\n",
+    "    display(UI, SVG(filename))\n",
+    "else:\n",
+    "    display(UI, interactive_plot)"
    ]
   }
  ],

--- a/docs/lambda-k-pi/automated.ipynb
+++ b/docs/lambda-k-pi/automated.ipynb
@@ -615,7 +615,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/lambda-k-pi/automated.ipynb
+++ b/docs/lambda-k-pi/automated.ipynb
@@ -766,7 +766,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/lambda-k-pi/automated.ipynb
+++ b/docs/lambda-k-pi/automated.ipynb
@@ -658,6 +658,7 @@
     "if STATIC_PAGE:\n",
     "    filename = \"dalitz-plot.png\"\n",
     "    fig_2d.savefig(filename)\n",
+    "    plt.close(fig_2d)\n",
     "    display(UI, Image(filename))\n",
     "else:\n",
     "    display(UI, interactive_plot)"
@@ -744,6 +745,7 @@
     "if STATIC_PAGE:\n",
     "    filename = \"histogram.svg\"\n",
     "    fig.savefig(filename)\n",
+    "    plt.close(fig)\n",
     "    display(UI, SVG(filename))\n",
     "else:\n",
     "    display(UI, interactive_plot)"


### PR DESCRIPTION
Plots that are generated with `%matplotlib widget` do not scale with the available margins on the rendered webpage. There is no good fix for this, but you can use the `EXECUTE_NB` variable to detect if the notebook was run through Sphinx. If so, the notebooks that plot with `%matplotlib widget` remove the figure and render an exported figure (png or svg) instead.


### Old
![image](https://github.com/user-attachments/assets/0ed10c78-b442-49ea-af2b-8572d11f8dd7)

### New
![image](https://github.com/user-attachments/assets/88babebe-945c-4bee-b344-7d8eaa5d4f70)
